### PR TITLE
[WIP] Add company-details page

### DIFF
--- a/src/pages/companies/__tests__/company-details.test.js
+++ b/src/pages/companies/__tests__/company-details.test.js
@@ -1,0 +1,46 @@
+import MockAdapter from 'axios-mock-adapter';
+import axios from '../../../service/api';
+import wrapper from '../../../test/test-utils';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { mockedCompany } from '../../../service/__tests__/fixtures/company';
+
+import CompanyDetails from '../company-details.component';
+
+const mockedApi = new MockAdapter(axios);
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: '1' }),
+}));
+
+describe('CompanyDetails page', () => {
+  describe('when successfully', () => {
+    beforeEach(() => {
+      mockedApi.onGet('/companies/1').reply(200, { ...mockedCompany });
+    });
+
+    it('renders company details', async () => {
+      wrapper(CompanyDetails);
+
+      await waitForElementToBeRemoved(screen.getByTestId('company-loading'));
+
+      expect(screen.getByText(mockedCompany.name)).toBeInTheDocument();
+    });
+  });
+
+  describe('when failure', () => {
+    beforeEach(() => {
+      mockedApi.onGet('/companies/1').reply(404);
+    });
+
+    it('shows errors', async () => {
+      wrapper(CompanyDetails);
+
+      await waitForElementToBeRemoved(screen.getByTestId('company-loading'));
+
+      expect(
+        await screen.findByText('Erro ao buscar dados da empresa')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/companies/company-details.component.js
+++ b/src/pages/companies/company-details.component.js
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { fetchCompany } from '../../service/company';
+
+import Template from '../../components/template/template.component';
+import { CircularProgress, Box } from '@material-ui/core';
+
+const initialCompanyState = { id: 0, name: 'Initial' };
+
+const CompanyDetails = () => {
+  const { id } = useParams();
+  const [company, setCompany] = useState(initialCompanyState);
+  const [loading, setLoading] = useState(false);
+
+  const onStart = () => setLoading(true);
+  const onSuccess = (data) => setCompany(data);
+  const onFailure = () => toast.error('Erro ao buscar dados da empresa');
+  const onCompleted = () => setLoading(false);
+
+  useEffect(() => {
+    if (!company.id)
+      fetchCompany({ id, onStart, onSuccess, onFailure, onCompleted });
+  }, [company, id]);
+
+  const render = () => {
+    if (loading)
+      return (
+        <Box display='flex' justifyContent='center'>
+          <div data-testid='company-loading'>
+            <CircularProgress />
+          </div>
+        </Box>
+      );
+
+    return (
+      <>
+        <h1>Detalhamento empresa</h1>
+        <p>{company.name}</p>
+      </>
+    );
+  };
+
+  return <Template>{render()}</Template>;
+};
+
+export default CompanyDetails;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,6 +4,7 @@ import SecureRoute from './secure-route.component';
 import LoginPage from '../pages/login/login.component';
 import Dashboard from '../pages/dashboard/dashboard.component';
 import ListUser from '../pages/list-user/list-user.component';
+import CompanyDetails from '../pages/companies/company-details.component';
 
 const Routes = () => {
   return (
@@ -12,6 +13,7 @@ const Routes = () => {
         <Route path='/' exact component={LoginPage} />
         <SecureRoute path='/dashboard' component={Dashboard} />
         <SecureRoute path='/users' component={ListUser} admin />
+        <SecureRoute path='/companies/:id' component={CompanyDetails} admin />
       </Switch>
     </Router>
   );

--- a/src/service/__tests__/fixtures/company.js
+++ b/src/service/__tests__/fixtures/company.js
@@ -1,0 +1,29 @@
+const mockedCompany = {
+  id: 1,
+  active: true,
+  address: 'Centro',
+  cnpj: '692077862000116',
+  code: '22306',
+  created_at: '2021-09-13T22:57:23.453Z',
+  discount: 2,
+  name: 'Nori4',
+  phone: '123456',
+  updated_at: '2021-09-14T00:33:29.270Z',
+  users: [
+    {
+      active: true,
+      address: 'Rua do Abacaxi, 13',
+      admin: false,
+      avatar: { url: null },
+      cellphone: '00000000',
+      cpf: '00000000001',
+      created_at: '2021-09-13T22:56:40.703Z',
+      email: 'regular@email.com',
+      full_name: 'Peao de obra',
+      id: 5,
+      updated_at: '2021-09-13T22:56:40.703Z',
+    },
+  ],
+};
+
+export { mockedCompany };

--- a/src/service/company.js
+++ b/src/service/company.js
@@ -1,0 +1,22 @@
+import api from './api';
+
+const fetchCompany = async ({
+  id,
+  onStart,
+  onSuccess,
+  onFailure,
+  onCompleted,
+}) => {
+  try {
+    onStart();
+    const { data } = await api.get(`/companies/${id}`);
+
+    onSuccess(data);
+  } catch (error) {
+    onFailure();
+  } finally {
+    onCompleted();
+  }
+};
+
+export { fetchCompany };

--- a/src/test/test-utils.js
+++ b/src/test/test-utils.js
@@ -2,6 +2,10 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import store from '../store';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components';
+import theme from '../styles/theme';
+import { ToastContainer } from 'react-toastify';
 
 const Wrapper = ({ children }) => <Provider store={store}>{children}</Provider>;
 
@@ -10,7 +14,12 @@ const wrapper = (children) => {
 
   return render(
     <Wrapper>
-      <Children />
+      <StyledThemeProvider theme={theme}>
+        <ThemeProvider theme={theme}>
+          <ToastContainer />
+          <Children />
+        </ThemeProvider>
+      </StyledThemeProvider>
     </Wrapper>,
     { wrapper: BrowserRouter }
   );


### PR DESCRIPTION
Depends on: https://github.com/comarev/comarev-dashboard/issues/14

Closes: https://github.com/comarev/comarev-dashboard/issues/16

### What?

Add `company-details` page, with the service which will fetch the company data from rails API.

### Why?

Since this page will be where users can update their companies.

### How it has been tested?

Writing some unit tests with jest, and also locally.

### Screenshots

![image](https://user-images.githubusercontent.com/47258878/140627145-ae51c4b8-791c-4246-8107-126549422030.png)
![image](https://user-images.githubusercontent.com/47258878/140627151-9b79b697-47c5-4dcf-8d79-38d83a916e8a.png)

