### PR TITLE
docs: add some credentials to sign in with fake users

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yarn start
 
 ```
 After application boot, you will see the login screen
-and you can is sign in with one of these following accounts:
+and you can sign in using one of the credentials below:
 
 ```
   email: admin@example.com

--- a/README.md
+++ b/README.md
@@ -53,7 +53,23 @@ Set the value of `REACT_APP_BASE_URL` pointing to your backend address and then 
 
 ```
 yarn start
+
 ```
+After application boot, you will see the login screen
+and you can is sign in with one of these following accounts:
+
+```
+  email: admin@example.com
+  password: 123456
+
+  email: manager@example.com
+  password: 123456
+
+  email: regular@example.com
+  password: 123456
+
+```
+
 
 ## Application Concepts
 


### PR DESCRIPTION
* docs: update README.md, add fake users credentials to sign in on app

#### What?

add credentials to sign in with different types of users on application 
like; `admin`, `emplpyee`, `manager`

#### Why?

as application don't have the action `sign  up`, the developer needs to sign in with an account that  
already exists.

#### How to test it?

- Describe how can we test the new feature/fixed bug.
