### PR TITLE
Adjust the grid component so that the input is not misaligned when the error message appears

### DIFF
--- a/src/pages/companies/form/company-form.component.js
+++ b/src/pages/companies/form/company-form.component.js
@@ -77,7 +77,6 @@ const CompanyForm = ({ onSubmit, loading, company }) => {
           <Grid
             container
             spacing={1}
-            alignItems='center'
             direction='row'
             justifycontent='center'
           >


### PR DESCRIPTION
References: #51 

#### What?

- Remove the "align-items: 'center'" prop from the Grid component

#### Why?

-  The "align-items" property was causing the input to be misaligned when the error message appeared

![Peek 2022-03-18 10-29](https://user-images.githubusercontent.com/77541655/159012152-47f2749c-3dc1-404e-847f-acdad2b23be7.gif)

