### PR TITLE
fix: cellphone, cnpj and currency parsers and formatters

### DIFF
--- a/cypress/integration/pages/companies/create_spec.page.js
+++ b/cypress/integration/pages/companies/create_spec.page.js
@@ -52,13 +52,11 @@ describe('Companies', () => {
     cy.intercept('POST', '/companies', (req) => {
       req.reply({
         statusCode: 422,
-        body: ['CNPJ não possui o tamanho esperado (14 caracteres)',
-          'Telefone não possui o tamanho esperado (14 caracteres)']
+        body: ['Telefone não possui o tamanho esperado (14 caracteres)']
       })
     })
     cy.get('button').contains('Cadastrar Empresa').click()
 
-    cy.findAllByText('CNPJ não possui o tamanho esperado (14 caracteres)').should('exist')
     cy.findAllByText('Telefone não possui o tamanho esperado (14 caracteres)').should('exist')
   })
 })

--- a/src/pages/users/form/user-form.component.js
+++ b/src/pages/users/form/user-form.component.js
@@ -58,7 +58,7 @@ const UserForm = ({ onSubmit, loading, user }) => {
           <RHFInput
             name='cellphone'
             label='Celular'
-            mask='(99) 999999999'
+            mask='+55 (999) 99999-9999'
             control={control}
           />
         </Grid>

--- a/src/service/company.js
+++ b/src/service/company.js
@@ -1,5 +1,6 @@
-import service from 'service/api';
-import { buildFormData } from 'utils/parsers/jsonToFormData';
+import service from '../service/api';
+import { buildFormData } from '../utils/parsers/jsonToFormData';
+import { onlyNumbers } from '../utils/parsers/general';
 
 const getCompanies = async ({ onStart, onFailure, onCompleted, onSuccess }) => {
   try {
@@ -35,7 +36,7 @@ const parseCompany = (payload) => {
     email,
     phone,
     address,
-    cnpj,
+    cnpj: onlyNumbers(cnpj),
     discount: parseFloat(discount),
     active: active ? JSON.parse(active) : false,
     manager_ids: managers?.map((manager) => manager.id) || [],

--- a/src/service/company.js
+++ b/src/service/company.js
@@ -1,6 +1,6 @@
-import service from '../service/api';
-import { buildFormData } from '../utils/parsers/jsonToFormData';
-import { onlyNumbers } from '../utils/parsers/general';
+import service from 'service/api';
+import { buildFormData } from 'utils/parsers/jsonToFormData';
+import { onlyNumbers } from 'utils/parsers/general';
 
 const getCompanies = async ({ onStart, onFailure, onCompleted, onSuccess }) => {
   try {

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -1,9 +1,9 @@
-import service from 'service/api';
-import { onlyNumbers } from 'utils/parsers/general';
+import service from '../service/api';
+import { onlyNumbers, parseCellphone } from '../utils/parsers/general';
 
 const parseUser = (user) => ({
   ...user,
-  cellphone: onlyNumbers(user.cellphone),
+  cellphone: parseCellphone(user.cellphone),
   cpf: onlyNumbers(user.cpf),
 });
 

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -1,5 +1,5 @@
-import service from '../service/api';
-import { onlyNumbers, parseCellphone } from '../utils/parsers/general';
+import service from 'service/api';
+import { onlyNumbers, parseCellphone } from 'utils/parsers/general';
 
 const parseUser = (user) => ({
   ...user,

--- a/src/utils/formatters/__tests__/general.test.js
+++ b/src/utils/formatters/__tests__/general.test.js
@@ -1,0 +1,20 @@
+import { formatCellphone, formatCpfCnpj } from '../general';
+
+describe('Formatters', () => {
+  describe('formatCellphone', () => {
+    it('should format cellphone', () => {
+      expect(formatCellphone('+5501612341234')).toBe('(016) 1234-1234');
+      expect(formatCellphone('+55016912341234')).toBe('(016) 91234-1234');
+    });
+  });
+
+  describe('formatCpfCnpj', () => {
+    it('should format cpf', () => {
+      expect(formatCpfCnpj('12345678901')).toBe('123.456.789-01');
+    });
+
+    it('should format cnpj', () => {
+      expect(formatCpfCnpj('12345678901234')).toBe('12.345.678/9012-34');
+    });
+  });
+});

--- a/src/utils/formatters/__tests__/general.test.js
+++ b/src/utils/formatters/__tests__/general.test.js
@@ -1,4 +1,4 @@
-import { formatCellphone, formatCpfCnpj } from '../general';
+import { formatCellphone, formatCpfCnpj } from 'utils/formatters/general';
 
 describe('Formatters', () => {
   describe('formatCellphone', () => {

--- a/src/utils/formatters/general.js
+++ b/src/utils/formatters/general.js
@@ -12,5 +12,5 @@ export const formatCpfCnpj = (value) => {
 };
 
 export const formatCellphone = (value) => {
-  return value.replace(/^(\d{2})\D*(\d{5}|\d{4})\D*(\d{4})$/g, '($1) $2-$3');
+  return value.replace(/^(\+\d{2})\D*(\d{3})\D*(\d{5}|\d{4})\D*(\d{4})$/g, '($2) $3-$4');
 };

--- a/src/utils/parsers/__tests__/general.test.js
+++ b/src/utils/parsers/__tests__/general.test.js
@@ -1,0 +1,22 @@
+import { onlyNumbers, parseCurrency, parseCellphone } from '../general';
+
+describe('Parsers', () => {
+  describe('onlyNumbers', () => {
+    it('should return a string with only numbers', () => {
+      expect(onlyNumbers('asd+11(123)11.2341234')).toBe('11123112341234');
+    });
+  });
+
+  describe('parseCurrency', () => {
+    it('should return only numbers', () => {
+      expect(parseCurrency('R$ 1.000,23')).toBe(1000.23);
+      expect(parseCurrency(1000.23)).toBe(1000.23);
+    });
+  });
+
+  describe('parseCellphone', () => {
+    it('should return a string with only numbers and a plus sign', () => {
+      expect(parseCellphone('+55(011)1234-1234')).toBe('+5501112341234');
+    });
+  });
+});

--- a/src/utils/parsers/__tests__/general.test.js
+++ b/src/utils/parsers/__tests__/general.test.js
@@ -1,4 +1,4 @@
-import { onlyNumbers, parseCurrency, parseCellphone } from '../general';
+import { onlyNumbers, parseCurrency, parseCellphone } from 'utils/parsers/general';
 
 describe('Parsers', () => {
   describe('onlyNumbers', () => {

--- a/src/utils/parsers/general.js
+++ b/src/utils/parsers/general.js
@@ -3,10 +3,14 @@ export const onlyNumbers = (value) => value.replace(/\D/g, '');
 export const parseCurrency = (value) => {
   if (typeof value === 'number') return value;
 
-  return value
+  const parsedValue = value
     .toString()
     .replace('.', '')
     .replace(',', '.')
     .replace('R$', '')
     .trim();
+
+  return Number(parsedValue)
 };
+
+export const parseCellphone = (value) => value.replace(/(?!\+)\D/g, '');


### PR DESCRIPTION
<!-- Thanks for sending a pr to comarev :D -->
<!-- what github issue is this PR for, if any? -->

Closes: #73

<!-- if this pr is not closing the issue, but it is related somehow -->



#### What?

Fix cellphone, CNPJ and currency formatters and parsers

#### Why?

It is not possible to create a user even when entering the data correctly.
![localhost_3001_users_new](https://user-images.githubusercontent.com/27422266/161259439-7f5fb41d-11fe-4a2f-870c-fc6af34f5661.png)
![localhost_3001_users_new (1)](https://user-images.githubusercontent.com/27422266/161259437-ebcb1e2e-8972-4408-adeb-ee305e0a1c89.png)
That occurs because the field Cellphone field on a user requires to be 15 characters long and must include a '+'



It is not possible to create a company even when entering the data correctly.
![localhost_3001_users_new (2)](https://user-images.githubusercontent.com/27422266/161259435-116f43be-fb49-44ce-a621-d4f7acb93999.png)
![localhost_3001_users_new (3)](https://user-images.githubusercontent.com/27422266/161259430-6e2b0590-5c49-4447-9172-684716bd221e.png)
That occurs because the field CNPJ on a company requires to be 14 characters long and cannot contain symbols


The currency parser currently can return a string or a number I changed it to always return a numeric value to maintain data consistency


#### How to test it?
User and Company creation should be possible after entering the correct data

`yarn test src/utils`
